### PR TITLE
Add MHN AI Agent Memory — Hopfield network-based agent memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5748,6 +5748,7 @@ Systems below are ordered by **publication date**:
 | Riverse | 2026-02-25 | ![GitHub Repo stars](https://img.shields.io/github/stars/wangjiake/JKRiver?style=social) | https://github.com/wangjiake/JKRiver<br>https://wangjiake.github.io/riverse-docs/ |
 | SuperLocalMemory | 2026-03-01 | ![GitHub Repo stars](https://img.shields.io/github/stars/qualixar/superlocalmemory?style=social) | https://github.com/qualixar/superlocalmemory<br>https://superlocalmemory.com/ |
 | NeverOnce | 2026-03-18 | ![GitHub Repo stars](https://img.shields.io/github/stars/WeberG619/neveronce?style=social) | https://github.com/WeberG619/neveronce<br>https://pypi.org/project/neveronce/ |
+| MHN AI Agent Memory | 2026-03-21 | ![GitHub Repo stars](https://img.shields.io/github/stars/shahzebqazi/mhn-ai-agent-memory?style=social) | https://github.com/shahzebqazi/mhn-ai-agent-memory<br>No official website |
 
 ### 🎥 Multi-media resource
 


### PR DESCRIPTION
MHN AI Agent Memory provides associative memory for AI agents using Modern Hopfield Networks. It does not rely on LLM calls or an external database: memory operations reduce to a matrix multiply for fast pattern retrieval.

Repository: https://github.com/shahzebqazi/mhn-ai-agent-memory

Made with [Cursor](https://cursor.com)