### PR TITLE
Add Agent Brain to Systems and Open Sources table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6033,6 +6033,7 @@ Systems below are ordered by **publication date**:
 | Cog | 2026-03-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/marciopuga/cog?style=social) | https://github.com/marciopuga/cog<br>No official website |
 | NeverOnce | 2026-03-18 | ![GitHub Repo stars](https://img.shields.io/github/stars/WeberG619/neveronce?style=social) | https://github.com/WeberG619/neveronce<br>https://pypi.org/project/neveronce/ |
 | MHN AI Agent Memory | 2026-03-21 | ![GitHub Repo stars](https://img.shields.io/github/stars/shahzebqazi/mhn-ai-agent-memory?style=social) | https://github.com/shahzebqazi/mhn-ai-agent-memory<br>No official website |
+| Agent Brain | 2024-12-01 | ![GitHub Repo stars](https://img.shields.io/github/stars/kaderosio/agent-brain?style=social) | https://github.com/kaderosio/agent-brain<br>No official website |
 
 ### 🎥 Multi-media resource
 


### PR DESCRIPTION
Adds [Agent Brain](https://github.com/kaderosio/agent-brain) to the Systems and Open Sources table.

Agent Brain is a 7-layer cognitive memory system for AI agents built with FastAPI, PostgreSQL, pgvector, sentence-transformers, and spaCy. Self-hostable, AGPLv3 licensed, no LLM required for memory operations.