### PR TITLE
Add Dakera — production-grade self-hosted MCP agent memory server (2026-05)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7532,6 +7532,7 @@ Systems below are ordered by **publication date**:
 | Origin | 2026-04-19 | ![GitHub Repo stars](https://img.shields.io/github/stars/7xuanlu/origin?style=social) | https://github.com/7xuanlu/origin<br>https://useorigin.app |
 | Omnigraph | 2026-04-22 | ![GitHub Repo stars](https://img.shields.io/github/stars/ModernRelay/omnigraph?style=social) | https://github.com/ModernRelay/omnigraph<br>No official website |
 | Mnemory | 2026-05-03 | ![GitHub Repo stars](https://img.shields.io/github/stars/fpytloun/mnemory?style=social) | https://github.com/fpytloun/mnemory<br>No official website |
+| Dakera | 2026-05-12 | ![GitHub Repo stars](https://img.shields.io/github/stars/dakera-ai/dakera-mcp?style=social) | https://github.com/dakera-ai/dakera-mcp<br>https://dakera.ai/ |
 
 ### 🎥 Multi-media resource
 


### PR DESCRIPTION
## Summary

Adding [Dakera](https://github.com/dakera-ai/dakera-mcp) to the **Systems and Open Sources** table, ordered by publication date (2026-05-12).

Dakera is a self-hosted AI agent memory server with published benchmark results on LoCoMo — the standard long-term conversational memory benchmark already referenced throughout this repo. It scores **87.8%**, which places it in the same tier as Mem0 (91.6%) and Letta/MemGPT (~88%), making it a meaningful addition to this list.

**What makes it distinct from existing entries:**
- **MCP-native**: Ships with 83 Model Context Protocol tools — not a wrapper, but a purpose-built MCP server for agent memory
- **Decay-weighted recall**: Importance scores degrade over configurable time windows, modeling natural memory salience — relevant to the cognitive/neuroscience-inspired framing of this repo
- **Self-hosted with zero LLM API deps**: Runs entirely offline with Rust + RocksDB + HNSW, no OpenAI/Anthropic calls required
- **Production deployment**: Docker Compose with MinIO object storage and Prometheus metrics included

GitHub: https://github.com/dakera-ai/dakera-mcp  
Website: https://dakera.ai/