### PR TITLE
Add Experience-RAG Skill paper on retrieval strategy orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 ![](https://img.shields.io/badge/PRs-Welcome-red)
-[![Papers](https://img.shields.io/badge/Papers-399-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
+[![Papers](https://img.shields.io/badge/Papers-400-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
 [![Open Source Projects](https://img.shields.io/badge/Open%20Source%20Projects-104-green.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/projects)
 
 
@@ -237,6 +237,26 @@ Papers below are ordered by **publication date**:
       <td><strong>Tags</strong></td>
       <td><strong>Links</strong></td>
     </tr>
+      <tr>
+        <td rowspan="2" style="width: 15%;">2026-05-19</td>
+        <td style="width: 55%;"><strong>An Agent-Oriented Pluggable Experience-RAG Skill for Experience-Driven Retrieval Strategy Orchestration</strong></td>
+        <td style="width: 15%;">
+          <img src="https://img.shields.io/badge/Agent%20Memory-blue" alt="Agent Memory">
+          <img src="https://img.shields.io/badge/Experience--RAG-yellow" alt="Experience-RAG">
+          <img src="https://img.shields.io/badge/Retrieval%20Strategy-orange" alt="Retrieval Strategy">
+          <img src="https://img.shields.io/badge/Skill%20Orchestration-green" alt="Skill Orchestration">
+        </td>
+        <td style="width: 15%;"><a href="https://arxiv.org/abs/2605.03989">
+          <img src="https://img.shields.io/badge/arXiv-Paper-%23D2691E?logo=arxiv" alt="Paper Badge">
+        </a></td>
+      </tr>
+      <tr>
+        <td colspan="3">
+          • Identifies three engineering problems in pipeline-based retrieval: non-reusable strategy logic, non-observable routing decisions, and non-evolvable workflow coupling.<br>
+          • Proposes Experience-RAG Skill with six modules (interface, scene analyzer, experience memory, strategy router, retriever pool, result packer) to encapsulate retrieval strategy selection as a pluggable agent skill.<br>
+          • Shows rule-based routing outperforms learned routing (0.8924 vs 0.8778/0.8627) under limited experience memory; experience memory records (scene_features, score_vector, best_margin) enable future upgrade to learning-based routing.
+        </td>
+      </tr>
       <tr>
         <td rowspan="2" style="width: 15%;">2026-04-17</td>
         <td style="width: 55%;"><strong>Human Cognition in Machines: A Unified Perspective of World Models</strong></td>

--- a/README_cn.md
+++ b/README_cn.md
@@ -11,7 +11,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 ![](https://img.shields.io/badge/PRs-Welcome-red)
-[![Papers](https://img.shields.io/badge/Papers-399-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
+[![Papers](https://img.shields.io/badge/Papers-400-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
 [![Open Source Projects](https://img.shields.io/badge/Open%20Source%20Projects-104-green.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/projects)
 
 
@@ -236,6 +236,26 @@ To systematically organize the diverse research and practical resources in the f
       <td><strong>标签</strong></td>
       <td><strong>链接</strong></td>
     </tr>
+      <tr>
+        <td rowspan="2" style="width: 15%;">2026-05-19</td>
+        <td style="width: 55%;"><strong>An Agent-Oriented Pluggable Experience-RAG Skill for Experience-Driven Retrieval Strategy Orchestration</strong></td>
+        <td style="width: 15%;">
+          <img src="https://img.shields.io/badge/Agent%20Memory-blue" alt="Agent Memory">
+          <img src="https://img.shields.io/badge/Experience--RAG-yellow" alt="Experience-RAG">
+          <img src="https://img.shields.io/badge/Retrieval%20Strategy-orange" alt="Retrieval Strategy">
+          <img src="https://img.shields.io/badge/Skill%20Orchestration-green" alt="Skill Orchestration">
+        </td>
+        <td style="width: 15%;"><a href="https://arxiv.org/abs/2605.03989">
+          <img src="https://img.shields.io/badge/arXiv-Paper-%23D2691E?logo=arxiv" alt="Paper Badge">
+        </a></td>
+      </tr>
+      <tr>
+        <td colspan="3">
+          • 识别了流水线式检索的三个工程问题：策略逻辑不可复用、路由决策不可观测、工作流耦合导致不可演进。<br>
+          • 提出 Experience-RAG Skill，包含六个模块（统一接口、场景分析、经验记忆、策略路由、检索器池、结果打包），将检索策略选择封装为可插拔的 Agent skill。<br>
+          • 规则路由（0.8924）优于学习路由（0.8778/0.8627），经验记忆记录 (scene_features, score_vector, best_margin) 为未来升级到学习路由奠定基础。
+        </td>
+      </tr>
       <tr>
         <td rowspan="2" style="width: 15%;">2026-04-17</td>
         <td style="width: 55%;"><strong>Human Cognition in Machines: A Unified Perspective of World Models</strong></td>


### PR DESCRIPTION
## Summary
- Add paper: **An Agent-Oriented Pluggable Experience-RAG Skill for Experience-Driven Retrieval Strategy Orchestration** (arXiv: 2605.03989)
- Identifies three engineering problems in pipeline-based retrieval: non-reusable strategy logic, non-observable routing decisions, and non-evolvable workflow coupling
- Proposes Experience-RAG Skill with six modules (interface, scene analyzer, experience memory, strategy router, retriever pool, result packer) to encapsulate retrieval strategy selection as a pluggable agent skill
- Rule-based routing (nDCG@10=0.8924) outperforms learned routing (0.8778/0.8627) under limited experience memory

## Test plan
- [x] Added paper entry to both `README.md` and `README_cn.md`
- [x] Updated paper count badges to 400

🤖 Generated with [Claude Code](https://claude.ai/code)