### PR TITLE
Add Agentic Task System

### DIFF
--- a/README.md
+++ b/README.md
@@ -7970,6 +7970,7 @@ Systems below are ordered by **publication date**:
 | Omnigraph | 2026-04-22 | ![GitHub Repo stars](https://img.shields.io/github/stars/ModernRelay/omnigraph?style=social) | https://github.com/ModernRelay/omnigraph<br>No official website |
 | Mnemory | 2026-05-03 | ![GitHub Repo stars](https://img.shields.io/github/stars/fpytloun/mnemory?style=social) | https://github.com/fpytloun/mnemory<br>No official website |
 | Dakera | 2026-05-12 | ![GitHub Repo stars](https://img.shields.io/github/stars/dakera-ai/dakera-mcp?style=social) | https://github.com/dakera-ai/dakera-mcp<br>https://dakera.ai/ |
+| Agentic Task System | 2026-05-29 | ![GitHub Repo stars](https://img.shields.io/github/stars/renezander030/agentic-task-system?style=social) | https://github.com/renezander030/agentic-task-system<br>https://www.npmjs.com/package/@reneza/ats-cli |
 
 ### 🎥 Multi-media resource
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -7944,6 +7944,7 @@ Framework for Experience-Driven Agent Evolution</strong></td>
 | Omnigraph | 2026-04-22 | ![GitHub Repo stars](https://img.shields.io/github/stars/ModernRelay/omnigraph?style=social) | https://github.com/ModernRelay/omnigraph<br>No official website |
 | Mnemory | 2026-05-03 | ![GitHub Repo stars](https://img.shields.io/github/stars/fpytloun/mnemory?style=social) | https://github.com/fpytloun/mnemory<br>No official website |
 | Dakera | 2026-05-12 | ![GitHub Repo stars](https://img.shields.io/github/stars/dakera-ai/dakera-mcp?style=social) | https://github.com/dakera-ai/dakera-mcp<br>https://dakera.ai/ |
+| Agentic Task System | 2026-05-29 | ![GitHub Repo stars](https://img.shields.io/github/stars/renezander030/agentic-task-system?style=social) | https://github.com/renezander030/agentic-task-system<br>https://www.npmjs.com/package/@reneza/ats-cli |
 
 ### 🎥 多媒体资源
 


### PR DESCRIPTION
## Summary
- Adds **Agentic Task System** to **🧰 Resources → 💻 Systems and Open Sources** (both README.md and README_cn.md), appended in publication-date order.

Repo: https://github.com/renezander030/agentic-task-system

An agent-native context layer that turns the task app you already use (TickTick today; Notion/Obsidian on the roadmap) into agent memory: hybrid retrieval (dense + sparse + keyword fused via RRF) over your tasks/notes, exposed to coding agents via a CLI with pluggable storage adapters. Fits the open-source systems table as a working memory/retrieval system.

MIT-licensed, actively maintained.

## Test plan
- [x] Added entry to README.md
- [x] Added entry to README_cn.md