### PR TITLE
Add Muse paper on multimodal conversational recommendation dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 ![](https://img.shields.io/badge/PRs-Welcome-red)
-[![Papers](https://img.shields.io/badge/Papers-402-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
+[![Papers](https://img.shields.io/badge/Papers-403-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
 [![Open Source Projects](https://img.shields.io/badge/Open%20Source%20Projects-104-green.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/projects)
 
 
@@ -6761,6 +6761,26 @@ Papers below are ordered by **publication date**:
         • Explores the importance of episodic memory in large language models (LLMs) and proposes the construction of new benchmarks to evaluate models’ reasoning capabilities.<br>
         • The authors develop a comprehensive framework with newly designed tasks and evaluation protocols, emphasizing the need for novel training strategies to effectively integrate episodic memory.<br>
         • The framework provides a promising solution for evaluating episodic memory in LLMs.
+      </td>
+    </tr>
+    <tr>
+      <td rowspan="2" style="width: 15%;">2024-12-24</td>
+      <td style="width: 55%;"><strong>Muse: A Multimodal Conversational Recommendation Dataset with Scenario-Grounded User Profiles</strong></td>
+      <td style="width: 15%;">
+        <img src="https://img.shields.io/badge/Dataset-seagreen" alt="Dataset">
+        <img src="https://img.shields.io/badge/Benchmark-darkred" alt="Benchmark">
+        <img src="https://img.shields.io/badge/Multimodal-darkorchid" alt="Multimodal">
+        <img src="https://img.shields.io/badge/Conversational%20Recommendation-mediumvioletred" alt="Conversational Recommendation">
+      </td>
+      <td style="width: 15%;"><a href="https://arxiv.org/abs/2412.18416">
+        <img src="https://img.shields.io/badge/arXiv-Paper-%23D2691E?logo=arxiv" alt="Paper Badge">
+      </a></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        • Introduces Muse, the first multimodal conversational recommendation dataset, containing 83,148 utterances across 7,000 conversations in the Clothing domain with scenario-grounded user profiles.<br>
+        • Proposes a three-stage multi-agent generation pipeline (User Profile Generator → Simulated Dialogue Generator → Dialogue Optimizer) powered by multimodal LLMs, where user profiles are derived from real-world scenarios rather than manual design, improving scalability.<br>
+        • Validates quality against four baselines (MMCONV, Redial, Inspired, PEARL) across five dimensions (naturalness, coherence, informativeness, product-context relevance, image-text consistency) and demonstrates utility by fine-tuning three MLLMs for recommendation and response generation.
       </td>
     </tr>
     <tr>

--- a/README_cn.md
+++ b/README_cn.md
@@ -11,7 +11,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 ![](https://img.shields.io/badge/PRs-Welcome-red)
-[![Papers](https://img.shields.io/badge/Papers-402-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
+[![Papers](https://img.shields.io/badge/Papers-403-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
 [![Open Source Projects](https://img.shields.io/badge/Open%20Source%20Projects-104-green.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/projects)
 
 
@@ -6757,6 +6757,26 @@ Framework for Experience-Driven Agent Evolution</strong></td>
         • 探讨情景记忆在大语言模型（LLMs）中的重要性，并提出构建新型基准测试框架以评估模型推理能力。<br>
         • 研究人员开发了包含全新设计任务与评估协议的综合性框架，强调需要创新训练策略以有效融合情景记忆机制。<br>
         • 该框架为评估大语言模型中的情景记忆提供了一种可行的技术路径。
+      </td>
+    </tr>
+    <tr>
+      <td rowspan="2" style="width: 15%;">2024-12-24</td>
+      <td style="width: 55%;"><strong>Muse: A Multimodal Conversational Recommendation Dataset with Scenario-Grounded User Profiles</strong></td>
+      <td style="width: 15%;">
+        <img src="https://img.shields.io/badge/Dataset-seagreen" alt="Dataset">
+        <img src="https://img.shields.io/badge/Benchmark-darkred" alt="Benchmark">
+        <img src="https://img.shields.io/badge/Multimodal-darkorchid" alt="Multimodal">
+        <img src="https://img.shields.io/badge/Conversational%20Recommendation-mediumvioletred" alt="Conversational Recommendation">
+      </td>
+      <td style="width: 15%;"><a href="https://arxiv.org/abs/2412.18416">
+        <img src="https://img.shields.io/badge/arXiv-Paper-%23D2691E?logo=arxiv" alt="Paper Badge">
+      </a></td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        • 提出首个多模态对话推荐数据集 Muse，在服装领域包含 7,000 段对话与 83,148 句话语，提供基于真实场景自动生成的用户画像。<br>
+        • 设计三阶段多智能体数据生成流程（用户画像生成器 → 模拟对话生成器 → 对话优化器），由多模态大模型驱动；用户画像源自真实场景而非人工设定，显著提升可扩展性。<br>
+        • 在自然性、连贯性、信息丰富性、产品上下文相关性、图文一致性五个维度上与 MMCONV、Redial、Inspired、PEARL 四个数据集对比评测；并通过对 3 个 MLLM 微调验证其在推荐与回复生成上的有效性。
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
## Summary
- Add Muse paper to Datasets & Benchmark section
- Paper introduces the first multimodal conversational recommendation dataset with scenario-grounded user profiles and a 3-stage multi-agent generation pipeline

## Paper Details
- **Title**: Muse: A Multimodal Conversational Recommendation Dataset with Scenario-Grounded User Profiles
- **Authors**: Zihan Wang, Xiaocui Yang, Yongkang Liu, Shi Feng, Daling Wang, Yifei Zhang
- **Affiliation**: Northeastern University
- **Venue**: ACL 2025
- **arXiv**: [2412.18416](https://arxiv.org/abs/2412.18416)
- **Scale**: 7,000 conversations / 83,148 utterances, Clothing domain

## Test plan
- [x] Added entry to README.md
- [x] Added entry to README_cn.md
- [x] Updated paper count badge (402 → 403)