### PR TITLE
Add taOSmd (local-first, benchmarked agent memory on a full transcript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7985,6 +7985,7 @@ Systems below are ordered by **publication date**:
 | SkillClaw | 2026-04-10 | ![GitHub Repo stars](https://img.shields.io/github/stars/AMAP-ML/SkillClaw?style=social) | https://github.com/AMAP-ML/SkillClaw<br>https://arxiv.org/abs/2604.08377 |
 | Synap | 2026-04-10 | ![GitHub Repo stars](https://img.shields.io/github/stars/maximem-ai/maximem_synap_sdk?style=social) | https://github.com/maximem-ai/maximem_synap_sdk<br>https://maximem.ai |
 | Formative Memory | 2026-04-11 | ![GitHub Repo stars](https://img.shields.io/github/stars/jarimustonen/formative-memory?style=social) | https://github.com/jarimustonen/formative-memory<br>No official website |
+| taOSmd | 2026-04-13 | ![GitHub Repo stars](https://img.shields.io/github/stars/jaylfc/taosmd?style=social) | https://github.com/jaylfc/taosmd<br>No official website |
 | ToolPipe | 2026-04-17 | ![GitHub Repo stars](https://img.shields.io/github/stars/COSAI-Labs/toolpipe-mcp-server?style=social) | https://github.com/COSAI-Labs/toolpipe-mcp-server<br>https://toolpipe.dev |
 | Origin | 2026-04-19 | ![GitHub Repo stars](https://img.shields.io/github/stars/7xuanlu/origin?style=social) | https://github.com/7xuanlu/origin<br>https://useorigin.app |
 | Omnigraph | 2026-04-22 | ![GitHub Repo stars](https://img.shields.io/github/stars/ModernRelay/omnigraph?style=social) | https://github.com/ModernRelay/omnigraph<br>No official website |


### PR DESCRIPTION
Adds **taOSmd** (https://github.com/jaylfc/taosmd), a local-first, offline agent memory system, to the list, following the existing entry format in this section.

What it is: an append-only, read-only transcript (user + agent messages, tool calls and results, decisions, errors) that a librarian derives a typed temporal knowledge graph and vector memory from. Corrected facts supersede old ones via invalidation (recall returns only the active fact). Hybrid vector + BM25 retrieval, tuned to run on small local models, fully offline (8GB RAM, no API keys). Benchmarked: 97.0% end-to-end Judge on LongMemEval-S and a same-tier leader result on LoCoMo (methodology in docs/benchmarks.md).

Open source (Python API + CLI today; MCP and a local HTTP API are work in progress). Happy to adjust placement, wording, or fields to match your conventions.