### PR TITLE
Add kaeru under Systems and Open Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -10068,6 +10068,7 @@ Systems below are ordered by **publication date**:
 | Origin | 2026-04-19 | ![GitHub Repo stars](https://img.shields.io/github/stars/7xuanlu/origin?style=social) | https://github.com/7xuanlu/origin<br>https://useorigin.app |
 | Omnigraph | 2026-04-22 | ![GitHub Repo stars](https://img.shields.io/github/stars/ModernRelay/omnigraph?style=social) | https://github.com/ModernRelay/omnigraph<br>No official website |
 | Mnemory | 2026-05-03 | ![GitHub Repo stars](https://img.shields.io/github/stars/fpytloun/mnemory?style=social) | https://github.com/fpytloun/mnemory<br>No official website |
+| kaeru | 2026-05-08 | ![GitHub Repo stars](https://img.shields.io/github/stars/LamantinAI/kaeru?style=social) | https://github.com/LamantinAI/kaeru<br>No official website |
 | Dakera | 2026-05-12 | ![GitHub Repo stars](https://img.shields.io/github/stars/dakera-ai/dakera-mcp?style=social) | https://github.com/dakera-ai/dakera-mcp<br>https://dakera.ai/ |
 | Perseus | 2026-05-18 | ![GitHub Repo stars](https://img.shields.io/github/stars/tcconnally/perseus?style=social) | https://github.com/tcconnally/perseus<br>https://perseus.observer/ |
 | Agentic Task System | 2026-05-29 | ![GitHub Repo stars](https://img.shields.io/github/stars/renezander030/agentic-task-system?style=social) | https://github.com/renezander030/agentic-task-system<br>https://www.npmjs.com/package/@reneza/ats-cli |


### PR DESCRIPTION
Adds [LamantinAI/kaeru](https://github.com/LamantinAI/kaeru) to the **Systems and Open Sources** table.

kaeru is a local-first cognitive memory system for LLM agents, exposed over MCP — a bi-temporal typed knowledge graph (CozoDB on RocksDB) giving agents long-term, cross-session and multi-agent continuity via episodes, provenance chains, and consolidated outcomes. Single Rust binary, MIT-licensed, with an optional shared cloud tier for teams.

- One new row, placed by first-release date (2026-05-08) to keep the table's publication-date ordering (between Mnemory and Dakera).