### PR TITLE
Add OpenRath paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 ![](https://img.shields.io/badge/PRs-Welcome-red)
-[![Papers](https://img.shields.io/badge/Papers-501-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
+[![Papers](https://img.shields.io/badge/Papers-502-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
 [![Open Source Projects](https://img.shields.io/badge/Open%20Source%20Projects-107-green.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/projects)
 
 
@@ -8686,6 +8686,28 @@ Papers below are ordered by **publication date**:
           • This paper introduces AtomMem, which adopts high-value atomic facts as the fundamental representational units of long-term memory. It seeks to balance the redundancy and overhead associated with preserving complete conversations against the loss of detail caused by excessive summarization, while mitigating the content drift and instability introduced by unconstrained memory updates.<br>
           • The system first employs a Fact Executor to selectively extract independent, verifiable, and information-dense facts from extended interactions, subsequently organizing them into hierarchical event structures and temporal profiles. The former preserve event-level episodic relationships, while the latter track dynamic changes in user preferences, goals, and attributes over time.<br>
           • During retrieval, an associative memory graph connects facts distributed across different events and time points to support cross-session, multi-hop, and temporal reasoning. Experiments on LoCoMo show that AtomMem achieves leading results across multiple reasoning categories, demonstrating that atomic representations must be integrated with event hierarchies, temporal evolution, and associative retrieval; merely partitioning memory into shorter text segments is insufficient to establish stable long-term memory.
+        </td>
+      </tr>
+      <tr>
+        <td rowspan="2" style="width: 15%;">2026-06-17</td>
+        <td style="width: 55%;"><strong>OpenRath: Session-Centered Runtime State for Agent Systems</strong></td>
+        <td style="width: 15%;">
+          <img src="https://img.shields.io/badge/Agent%20Runtime-4A90E2" alt="Agent Runtime">
+          <img src="https://img.shields.io/badge/Session%20State-F5A623" alt="Session State">
+          <img src="https://img.shields.io/badge/Replay-7ED321" alt="Replay">
+          <img src="https://img.shields.io/badge/Memory%20Events-D0021B" alt="Memory Events">
+        </td>
+        <td style="width: 15%;">
+          <a href="https://arxiv.org/pdf/2606.19409v1">
+            <img src="https://img.shields.io/badge/arXiv-Paper-D2691E?logo=arxiv" alt="Paper Badge">
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="3">
+          • This paper addresses fragmented runtime state in modern agent systems, where transcripts, tool effects, memory events, workspace placement, branch provenance, and replay evidence are often recorded separately and become difficult to inspect or reproduce.<br>
+          • OpenRath introduces a PyTorch-like programming model whose central abstraction is a first-class Session value passed between agents and workflows. A Session is branchable, inspectable, replayable, backend-aware, and composable, carrying conversation chunks, sandbox placement, lineage metadata, token usage, pending work, tool evidence, and the runtime record of memory interactions.<br>
+          • By making fork, merge, and replay explicit runtime operations, and by defining Sandbox, Tool, Agent, Memory, Workflow, and Selector components, OpenRath provides an auditable composition model for multi-agent, multi-session systems. The report focuses on controlled runtime properties, leaving broader live-provider quality and memory-quality evaluation to follow-on work.
         </td>
       </tr>
       <tr>

--- a/README_cn.md
+++ b/README_cn.md
@@ -11,7 +11,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 ![](https://img.shields.io/badge/PRs-Welcome-red)
-[![Papers](https://img.shields.io/badge/Papers-501-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
+[![Papers](https://img.shields.io/badge/Papers-502-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
 [![Open Source Projects](https://img.shields.io/badge/Open%20Source%20Projects-107-green.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/projects)
 
 
@@ -8688,6 +8688,28 @@ Framework for Experience-Driven Agent Evolution</strong></td>
           • 本文提出AtomMem，以高价值原子事实作为长期记忆的基本表示单位，试图在保存完整对话造成的冗余开销与过度摘要导致的细节损失之间取得平衡，并降低无约束记忆更新带来的内容漂移和不稳定性。<br>
           • 系统首先由Fact Executor从长篇交互中选择性提取独立、可验证且信息密度较高的事实，再将其组织为分层事件结构和时间画像：前者保留事件级情景关系，后者跟踪用户偏好、目标及属性随时间发生的动态变化。<br>
           • 检索阶段通过关联记忆图连接分散在不同事件与时间点的事实，以支持跨会话、多跳和时间推理；LoCoMo实验显示AtomMem在多类推理任务上取得领先结果，表明原子化表示需要与事件层次、时间演化和关联检索共同使用，单纯将记忆切分为更短文本并不足以形成稳定的长期记忆。
+        </td>
+      </tr>
+      <tr>
+        <td rowspan="2" style="width: 15%;">2026-06-17</td>
+        <td style="width: 55%;"><strong>OpenRath: Session-Centered Runtime State for Agent Systems</strong></td>
+        <td style="width: 15%;">
+          <img src="https://img.shields.io/badge/Agent%20Runtime-4A90E2" alt="Agent Runtime">
+          <img src="https://img.shields.io/badge/Session%20State-F5A623" alt="Session State">
+          <img src="https://img.shields.io/badge/Replay-7ED321" alt="Replay">
+          <img src="https://img.shields.io/badge/Memory%20Events-D0021B" alt="Memory Events">
+        </td>
+        <td style="width: 15%;">
+          <a href="https://arxiv.org/pdf/2606.19409v1">
+            <img src="https://img.shields.io/badge/arXiv-Paper-D2691E?logo=arxiv" alt="Paper Badge">
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="3">
+          • 本文针对现代 Agent 系统中的运行时状态碎片化问题展开研究：对话记录、工具效果、记忆事件、工作区位置、分支来源与重放证据往往分散记录，导致系统难以检查和复现。<br>
+          • OpenRath 提出类似 PyTorch 的编程模型，其核心抽象是在线程、代理和工作流之间传递的一等公民 Session 值；Session 支持分支、检查、重放、后端感知与组合，并携带对话片段、沙箱位置、血缘元数据、token 用量、待处理任务、工具证据以及记忆交互的运行时记录。<br>
+          • 通过将 fork、merge 和 replay 显式建模为运行时操作，并定义 Sandbox、Tool、Agent、Memory、Workflow 与 Selector 等组件，OpenRath 为多代理、多会话系统提供了可审计的组合模型；论文主要验证受控运行时属性，开放服务质量和记忆质量评估留待后续工作。
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
## Summary
- Add paper: OpenRath: Session-Centered Runtime State for Agent Systems
- Add an agent runtime paper that treats session state, memory events, and replay evidence as first-class runtime records.

## Paper Details
- **Title**: OpenRath: Session-Centered Runtime State for Agent Systems
- **Authors**: Fukang Wen, Zhijie Wang, Ruilin Xu
- **arXiv**: [2606.19409](https://arxiv.org/abs/2606.19409)

## Test plan
- [x] Added entry to README.md
- [x] Added entry to README_cn.md
- [x] Ran scripts/update_paper_count.py