### PR TITLE
Add Qwen-AgentWorld paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 ![](https://img.shields.io/badge/PRs-Welcome-red)
-[![Papers](https://img.shields.io/badge/Papers-501-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
+[![Papers](https://img.shields.io/badge/Papers-502-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
 [![Open Source Projects](https://img.shields.io/badge/Open%20Source%20Projects-107-green.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/projects)
 
 
@@ -8666,6 +8666,28 @@ Papers below are ordered by **publication date**:
       <td><strong>Tags</strong></td>
       <td><strong>Links</strong></td>
     </tr>
+      <tr>
+        <td rowspan="2" style="width: 15%;">2026-06-23</td>
+        <td style="width: 55%;"><strong>Qwen-AgentWorld: Language World Models for General Agents</strong></td>
+        <td style="width: 15%;">
+          <img src="https://img.shields.io/badge/Language%20World%20Model-4A90E2" alt="Language World Model">
+          <img src="https://img.shields.io/badge/General%20Agents-F5A623" alt="General Agents">
+          <img src="https://img.shields.io/badge/Environment%20Simulation-7ED321" alt="Environment Simulation">
+          <img src="https://img.shields.io/badge/Agentic%20RL-D0021B" alt="Agentic RL">
+        </td>
+        <td style="width: 15%;">
+          <a href="https://arxiv.org/pdf/2606.24597v1">
+            <img src="https://img.shields.io/badge/arXiv-Paper-D2691E?logo=arxiv" alt="Paper Badge">
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="3">
+          • This paper introduces Qwen-AgentWorld, a family of language world models that predict agentic environment dynamics from observations and actions, positioning world modeling as a core mechanism for reasoning, planning, and scalable agent training.<br>
+          • The models are trained from more than 10 million real environment interaction trajectories across seven agentic domains. The training pipeline combines continued pretraining for world-modeling capabilities, supervised fine-tuning for next-state prediction, and reinforcement learning with hybrid rubric-and-rule rewards to improve simulation fidelity.<br>
+          • Qwen-AgentWorld supports two complementary uses: as a decoupled simulator for scalable agentic reinforcement learning, and as a unified agent foundation model whose world-model training improves downstream performance across seven agentic benchmarks. The paper also introduces AgentWorldBench for evaluating language world models from real-world interactions.
+        </td>
+      </tr>
       <tr>
         <td rowspan="2" style="width: 15%;">2026-06-18</td>
         <td style="width: 55%;"><strong>AtomMem: Building Simple and Effective Memory System for LLM Agents via Atomic Facts</strong></td>

--- a/README_cn.md
+++ b/README_cn.md
@@ -11,7 +11,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 ![](https://img.shields.io/badge/PRs-Welcome-red)
-[![Papers](https://img.shields.io/badge/Papers-501-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
+[![Papers](https://img.shields.io/badge/Papers-502-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
 [![Open Source Projects](https://img.shields.io/badge/Open%20Source%20Projects-107-green.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/projects)
 
 
@@ -8668,6 +8668,28 @@ Framework for Experience-Driven Agent Evolution</strong></td>
       <td><strong>标签</strong></td>
       <td><strong>链接</strong></td>
     </tr>
+      <tr>
+        <td rowspan="2" style="width: 15%;">2026-06-23</td>
+        <td style="width: 55%;"><strong>Qwen-AgentWorld: Language World Models for General Agents</strong></td>
+        <td style="width: 15%;">
+          <img src="https://img.shields.io/badge/Language%20World%20Model-4A90E2" alt="Language World Model">
+          <img src="https://img.shields.io/badge/General%20Agents-F5A623" alt="General Agents">
+          <img src="https://img.shields.io/badge/Environment%20Simulation-7ED321" alt="Environment Simulation">
+          <img src="https://img.shields.io/badge/Agentic%20RL-D0021B" alt="Agentic RL">
+        </td>
+        <td style="width: 15%;">
+          <a href="https://arxiv.org/pdf/2606.24597v1">
+            <img src="https://img.shields.io/badge/arXiv-Paper-D2691E?logo=arxiv" alt="Paper Badge">
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="3">
+          • 本文提出 Qwen-AgentWorld，一组根据观测和动作预测智能体环境动态的语言世界模型，将世界建模定位为推理、规划与可扩展智能体训练的核心机制。<br>
+          • 模型使用来自七个智能体领域、超过 1000 万条真实环境交互轨迹训练；训练流程结合持续预训练以注入世界建模能力、监督微调以激活下一状态预测，以及带混合 rubric 和规则奖励的强化学习以提升模拟保真度。<br>
+          • Qwen-AgentWorld 支持两类互补用法：作为解耦环境模拟器支撑大规模 agentic reinforcement learning，以及作为统一智能体基础模型，通过世界模型训练提升七个下游 agentic benchmark 的表现；论文还提出 AgentWorldBench，用真实交互评估语言世界模型。
+        </td>
+      </tr>
       <tr>
         <td rowspan="2" style="width: 15%;">2026-06-18</td>
         <td style="width: 55%;"><strong>AtomMem: Building Simple and Effective Memory System for LLM Agents via Atomic Facts</strong></td>


### PR DESCRIPTION
## Summary
- Add paper: Qwen-AgentWorld: Language World Models for General Agents
- Add a language world model paper for agentic environment simulation and general agent training.

## Paper Details
- **Title**: Qwen-AgentWorld: Language World Models for General Agents
- **Authors**: Yuxin Zuo, Zikai Xiao, Li Sheng, Fei Huang, Jianhong Tu, Yuxuan Liu, Tianyi Tang, Xiaomeng Hu, Yang Su, Qingfeng Lan, et al.
- **arXiv**: [2606.24597](https://arxiv.org/abs/2606.24597)

## Test plan
- [x] Added entry to README.md
- [x] Added entry to README_cn.md
- [x] Ran scripts/update_paper_count.py