### PR TITLE
Add Compartment to Systems and Open Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -10853,6 +10853,7 @@ Systems below are ordered by **publication date**:
 | AccInt | 2026-06-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/maxbaluev/accreted-intelligence?style=social) | https://github.com/maxbaluev/accreted-intelligence<br>https://accint.xyz/ |
 | Tree Ring Memory | 2026-07-07 | ![GitHub Repo stars](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory?style=social) | https://github.com/TerminallyLazy/Tree-Ring-Memory<br>https://terminallylazy.github.io/Tree-Ring-Memory/ |
 | Data Olympus | 2026-07-08 | ![GitHub Repo stars](https://img.shields.io/github/stars/knaisoma/data-olympus?style=social) | https://github.com/knaisoma/data-olympus<br>No official website |
+| engRAM | 2026-07-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/engRAM?style=social) | https://github.com/MaxFreedomPollard/engRAM<br>No official website |
 
 ### 🎥 Multi-media resource
 

--- a/README.md
+++ b/README.md
@@ -10853,7 +10853,7 @@ Systems below are ordered by **publication date**:
 | AccInt | 2026-06-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/maxbaluev/accreted-intelligence?style=social) | https://github.com/maxbaluev/accreted-intelligence<br>https://accint.xyz/ |
 | Tree Ring Memory | 2026-07-07 | ![GitHub Repo stars](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory?style=social) | https://github.com/TerminallyLazy/Tree-Ring-Memory<br>https://terminallylazy.github.io/Tree-Ring-Memory/ |
 | Data Olympus | 2026-07-08 | ![GitHub Repo stars](https://img.shields.io/github/stars/knaisoma/data-olympus?style=social) | https://github.com/knaisoma/data-olympus<br>No official website |
-| engRAM | 2026-07-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/engRAM?style=social) | https://github.com/MaxFreedomPollard/engRAM<br>No official website |
+| Compartment | 2026-07-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social) | https://github.com/MaxFreedomPollard/Compartment<br>No official website |
 
 ### 🎥 Multi-media resource
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -10813,6 +10813,7 @@ Framework for Experience-Driven Agent Evolution</strong></td>
 | AccInt | 2026-06-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/maxbaluev/accreted-intelligence?style=social) | https://github.com/maxbaluev/accreted-intelligence<br>https://accint.xyz/ |
 | Tree Ring Memory | 2026-07-07 | ![GitHub Repo stars](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory?style=social) | https://github.com/TerminallyLazy/Tree-Ring-Memory<br>https://terminallylazy.github.io/Tree-Ring-Memory/ |
 | Data Olympus | 2026-07-08 | ![GitHub Repo stars](https://img.shields.io/github/stars/knaisoma/data-olympus?style=social) | https://github.com/knaisoma/data-olympus<br>No official website |
+| engRAM | 2026-07-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/engRAM?style=social) | https://github.com/MaxFreedomPollard/engRAM<br>No official website |
 
 ### 🎥 多媒体资源
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -10813,7 +10813,7 @@ Framework for Experience-Driven Agent Evolution</strong></td>
 | AccInt | 2026-06-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/maxbaluev/accreted-intelligence?style=social) | https://github.com/maxbaluev/accreted-intelligence<br>https://accint.xyz/ |
 | Tree Ring Memory | 2026-07-07 | ![GitHub Repo stars](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory?style=social) | https://github.com/TerminallyLazy/Tree-Ring-Memory<br>https://terminallylazy.github.io/Tree-Ring-Memory/ |
 | Data Olympus | 2026-07-08 | ![GitHub Repo stars](https://img.shields.io/github/stars/knaisoma/data-olympus?style=social) | https://github.com/knaisoma/data-olympus<br>No official website |
-| engRAM | 2026-07-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/engRAM?style=social) | https://github.com/MaxFreedomPollard/engRAM<br>No official website |
+| Compartment | 2026-07-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social) | https://github.com/MaxFreedomPollard/Compartment<br>No official website |
 
 ### 🎥 多媒体资源
 


### PR DESCRIPTION
Adds **Compartment** to *Systems and Open Sources* in both `README.md` and `README_cn.md`, in the same table format and date order as the surrounding rows.

Fully offline, encrypted-at-rest vector memory for AI agents: every byte at rest is AEAD-encrypted including the embedding vectors, with RAM-resident exact vector search, per-record crypto-shred deletion and a hash-chained audit log. Usable as an MCP server or a Python/CLI library; no API key or cloud required. Apache-2.0.

*Note: the project was renamed from engRAM to Compartment while this PR was open, and is licensed Apache-2.0. The repository is now [MaxFreedomPollard/Compartment](https://github.com/MaxFreedomPollard/Compartment) and the old URL redirects there.*
