### PR TITLE
Add mem0ry4ai to Systems and Open Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 ![](https://img.shields.io/badge/PRs-Welcome-red)
 [![Papers](https://img.shields.io/badge/Papers-540-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
-[![Open Source Projects](https://img.shields.io/badge/Open%20Source%20Projects-110-green.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/projects)
+[![Open Source Projects](https://img.shields.io/badge/Open%20Source%20Projects-111-green.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/projects)
 
 
 ## 👋 Introduction
@@ -10850,6 +10850,7 @@ Systems below are ordered by **publication date**:
 | OWASP Agent Memory Guard | 2026-05-30 | ![GitHub Repo stars](https://img.shields.io/github/stars/OWASP/www-project-agent-memory-guard?style=social) | https://github.com/OWASP/www-project-agent-memory-guard<br>https://pypi.org/project/agent-memory-guard/ |
 | Engrava | 2026-06-02 | ![GitHub Repo stars](https://img.shields.io/github/stars/sovantica/engrava?style=social) | https://github.com/sovantica/engrava<br>https://engrava.ai |
 | Mimir | 2026-06-06 | ![GitHub Repo stars](https://img.shields.io/github/stars/tcconnally/mimir?style=social) | https://github.com/tcconnally/mimir<br>https://perseus.observer/mimir |
+| mem0ry4ai | 2026-06-11 | ![GitHub Repo stars](https://img.shields.io/github/stars/cremenescu/mem0ry4ai?style=social) | https://github.com/cremenescu/mem0ry4ai<br>https://cremenescu.ro/en/mem0ry4ai/ |
 | AccInt | 2026-06-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/maxbaluev/accreted-intelligence?style=social) | https://github.com/maxbaluev/accreted-intelligence<br>https://accint.xyz/ |
 | Tree Ring Memory | 2026-07-07 | ![GitHub Repo stars](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory?style=social) | https://github.com/TerminallyLazy/Tree-Ring-Memory<br>https://terminallylazy.github.io/Tree-Ring-Memory/ |
 | Data Olympus | 2026-07-08 | ![GitHub Repo stars](https://img.shields.io/github/stars/knaisoma/data-olympus?style=social) | https://github.com/knaisoma/data-olympus<br>No official website |

--- a/README_cn.md
+++ b/README_cn.md
@@ -12,7 +12,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 ![](https://img.shields.io/badge/PRs-Welcome-red)
 [![Papers](https://img.shields.io/badge/Papers-540-blue.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/papers)
-[![Open Source Projects](https://img.shields.io/badge/Open%20Source%20Projects-110-green.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/projects)
+[![Open Source Projects](https://img.shields.io/badge/Open%20Source%20Projects-111-green.svg)](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/projects)
 
 
 ## 👋 简介
@@ -10810,6 +10810,7 @@ Framework for Experience-Driven Agent Evolution</strong></td>
 | OWASP Agent Memory Guard | 2026-05-30 | ![GitHub Repo stars](https://img.shields.io/github/stars/OWASP/www-project-agent-memory-guard?style=social) | https://github.com/OWASP/www-project-agent-memory-guard<br>https://pypi.org/project/agent-memory-guard/ |
 | Engrava | 2026-06-02 | ![GitHub Repo stars](https://img.shields.io/github/stars/sovantica/engrava?style=social) | https://github.com/sovantica/engrava<br>https://engrava.ai |
 | Mimir | 2026-06-06 | ![GitHub Repo stars](https://img.shields.io/github/stars/tcconnally/mimir?style=social) | https://github.com/tcconnally/mimir<br>https://perseus.observer/mimir |
+| mem0ry4ai | 2026-06-11 | ![GitHub Repo stars](https://img.shields.io/github/stars/cremenescu/mem0ry4ai?style=social) | https://github.com/cremenescu/mem0ry4ai<br>https://cremenescu.ro/en/mem0ry4ai/ |
 | AccInt | 2026-06-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/maxbaluev/accreted-intelligence?style=social) | https://github.com/maxbaluev/accreted-intelligence<br>https://accint.xyz/ |
 | Tree Ring Memory | 2026-07-07 | ![GitHub Repo stars](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory?style=social) | https://github.com/TerminallyLazy/Tree-Ring-Memory<br>https://terminallylazy.github.io/Tree-Ring-Memory/ |
 | Data Olympus | 2026-07-08 | ![GitHub Repo stars](https://img.shields.io/github/stars/knaisoma/data-olympus?style=social) | https://github.com/knaisoma/data-olympus<br>No official website |


### PR DESCRIPTION
Adds **mem0ry4ai** to `## 🧰 Resources` → `### 💻 Systems and Open Sources`.

**Repo:** https://github.com/cremenescu/mem0ry4ai · **Website:** https://cremenescu.ro/en/mem0ry4ai/

Local-first, long-term memory for LLM agents. Plain markdown files versioned by git are the source of truth; the SQLite FTS5 index and the optional local embedding index are both derived and rebuildable. Memory management covers write / update / supersede / forget with a human review gate, and retrieval is hybrid (FTS5 bm25 fused with optional Ollama embeddings via RRF, degrading to keyword search offline). It integrates with agents two ways: Claude Code session hooks that inject the project-scoped slice automatically, and a built-in stdio MCP server (8 tools) for any other MCP client. Secrets are redacted before every write. Pure Python stdlib, no third-party dependencies. GPL-2.0-or-later.

Changes, following the convention of the recent system-addition PRs:
- Row inserted in **publication-date order** (2026-06-11), between `Mimir` (2026-06-06) and `AccInt` (2026-06-15) — not alphabetically, not appended at the end.
- Same row added to **both** `README.md` and `README_cn.md` (identical English row, per the existing table).
- Project-count badge bumped `110` → `111` in both files.

Diff is 4 added lines and 2 changed badge lines across the two READMEs; nothing else touched.