### PR TITLE
Add NapMem and Proactive Memory Agent papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ To systematically organize the diverse research and practical resources in the f
 --- -->
 
 ## 🔔 Recent hot research and news
++ 2026-07-28 - 🎉 Updated 2 papers on Framework & Methods (NapMem: Memory Navigation, Proactive Memory Agent)
 + 2026-07-06 - 🎉 Updated 25 papers, including 4 on Datasets & Benchmark, and 23 on Framework & Methods
 + 2026-06-14 - 🎉 Updated 24 papers, including 2 on Survey, 4 on Systems & Models, 2 on Datasets & Benchmark, and 16 on Framework & Methods
 + 2026-06-06 - 🎉 Updated 45 papers, including 1 on Survey, 6 on Systems & Models, 12 on Datasets & Benchmark, and 26 on Framework & Methods
@@ -750,6 +751,26 @@ Papers below are ordered by **publication date**:
       <td><strong>Links</strong></td>
     </tr>
     <tr>
+    <td rowspan="2" style="width: 15%;">2026-07-09</td>
+    <td style="width: 55%;"><strong>Remember When It Matters: Proactive Memory Agent for Long-Horizon Agents</strong></td>
+    <td style="width: 15%;">
+        <img src="https://img.shields.io/badge/Proactive%20Memory-blue" alt="Proactive Memory">
+        <img src="https://img.shields.io/badge/Long--Horizon%20Tasks-green" alt="Long-Horizon Tasks">
+        <img src="https://img.shields.io/badge/Agent%20Memory-orange" alt="Agent Memory">
+        <img src="https://img.shields.io/badge/RL%20Policy-red" alt="RL Policy">
+    </td>
+    <td style="width: 15%;"><a href="https://arxiv.org/pdf/2607.08716">
+        <img src="https://img.shields.io/badge/arXiv-Paper-%23D2691E?logo=arxiv" alt="Paper Badge">
+    </a></td>
+</tr>
+  <tr>
+      <td colspan="3">
+          • This paper studies memory as an active intervention mechanism rather than passive retrieval. A separate memory agent runs alongside an unmodified action agent, updating a structured memory bank from the recent trajectory and deciding whether to inject a memory-grounded reminder (forgotten requirement, environment fact, failed attempt, or diagnosis) or remain silent.<br>
+          • Introduces the concept of "behavioral state decay": as trajectories grow, task requirements, environment facts, prior attempts, diagnoses, and open subgoals can be buried in or pushed beyond the context window, failing to influence decisions when needed.<br>
+          • Across Terminal-Bench 2.0 and τ²-Bench, the plug-and-play module improves pass@1 by +8.3 pp and +6.8 pp respectively. Ablations show selective intervention outperforms passive bank exposure, always-on injection, advisor-only guidance, and general retrieval. Also trains Qwen3.5-27B on SETA using SFT and GRPO for open-weight memory policies.
+      </td>
+  </tr>
+  <tr>
     <td rowspan="2" style="width: 15%;">2026-07-02</td>
     <td style="width: 55%;"><strong>DRIFTLENS: Measuring Memory-Induced Reasoning Drift in Personalized Language Models</strong></td>
     <td style="width: 15%;">

--- a/README_cn.md
+++ b/README_cn.md
@@ -106,6 +106,7 @@ To systematically organize the diverse research and practical resources in the f
 --- -->
 
 ## 🔔 近期热点研究与新闻
++ 2026-07-28 - 🎉 更新2篇方法类与框架类论文（NapMem: 记忆导航, Proactive Memory Agent: 主动记忆）
 + 2026-07-06 - 🎉 更新25篇论文，数据集和评估基准类5篇，方法类与框架类23篇
 + 2026-06-21 - 🎉 更新27篇论文，模型和系统类9篇，数据集和评估基准类5篇，方法类与框架类13篇
 + 2026-06-14 - 🎉 更新24篇论文，综述类2篇，模型和系统类4篇，数据集和评估基准类2篇，方法类与框架类16篇
@@ -750,6 +751,26 @@ To systematically organize the diverse research and practical resources in the f
       <td><strong>链接</strong></td>
     </tr>
     <tr>
+      <td rowspan="2" style="width: 15%;">2026-07-09</td>
+      <td style="width: 55%;"><strong>在重要时记住它：用于长程 Agent 的主动记忆 Agent</strong></td>
+      <td style="width: 15%;">
+          <img src="https://img.shields.io/badge/Proactive%20Memory-blue" alt="Proactive Memory">
+          <img src="https://img.shields.io/badge/Long--Horizon%20Tasks-green" alt="Long-Horizon Tasks">
+          <img src="https://img.shields.io/badge/Agent%20Memory-orange" alt="Agent Memory">
+          <img src="https://img.shields.io/badge/RL%20Policy-red" alt="RL Policy">
+      </td>
+      <td style="width: 15%;"><a href="https://arxiv.org/pdf/2607.08716">
+          <img src="https://img.shields.io/badge/arXiv-论文-%23D2691E?logo=arxiv" alt="论文徽章">
+      </a></td>
+  </tr>
+  <tr>
+      <td colspan="3">
+          • 本文将记忆视为一种主动干预机制而非被动检索。一个独立的记忆 Agent 与未修改的行动 Agent 并行运行，从最近的轨迹更新结构化记忆库，并决定是否注入基于记忆的提醒（被遗忘的需求、环境事实、失败尝试或诊断），或保持沉默。<br>
+          • 引入"行为状态衰减"概念：随着轨迹增长，任务需求、环境事实、先前尝试、诊断和开放子目标可能被埋没在上下文窗口中或被推出，在需要时无法影响决策。<br>
+          • 在 Terminal-Bench 2.0 和 τ²-Bench 上，即插即用模块分别将 pass@1 提高了 +8.3 和 +6.8 个百分点。消融实验表明，选择性干预优于被动库暴露、持续注入、仅顾问指导和通用检索。还使用 SFT 和 GRPO 在 SETA 上训练 Qwen3.5-27B 以实现开放权重记忆策略。
+      </td>
+  </tr>
+  <tr>
       <td rowspan="2" style="width: 15%;">2026-07-02</td>
       <td style="width: 55%;"><strong>DRIFTLENS: Measuring Memory-Induced Reasoning Drift in Personalized Language Models</strong></td>
       <td style="width: 15%;">


### PR DESCRIPTION
## Summary
Closes #121

Add two recent Agent Memory papers to the Framework & Methods section:

### 1. NapMem (2026-07-07)
- **Title**: From Passive Retrieval to Active Memory Navigation: Learning to Use Memory as a Structured Action Space
- **Authors**: Yue Xu et al. (Alibaba)
- **arXiv**: [2607.05794](https://arxiv.org/abs/2607.05794)
- **Contribution**: Treats long-term user memory as a structured action space. Organizes user history into a linked multi-granularity memory pyramid and trains agents via memory-tool RL to actively navigate memory.

### 2. Remember When It Matters (2026-07-09)
- **Title**: Remember When It Matters: Proactive Memory Agent for Long-Horizon Agents
- **Authors**: Yifan Wu et al. (Meta AI)
- **arXiv**: [2607.08716](https://arxiv.org/abs/2607.08716)
- **Contribution**: Introduces the concept of behavioral state decay and studies memory as an active intervention mechanism rather than passive retrieval. A plug-and-play memory agent runs alongside action agents, improving pass@1 by +8.3 pp on Terminal-Bench 2.0.

## Changes
- Add 2 paper entries (English) to README.md under Framework & Methods
- Add 2 paper entries (Chinese) to README_cn.md under 方法类与框架类
- Add news entries to both README files for 2026-07-28

## Test plan
- [x] Inserted in Framework & Methods section in reverse chronological order (2026-07-09, 2026-07-07, 2026-07-02)
- [x] Added entries to README.md
- [x] Added entries to README_cn.md
- [x] Added news entries in both files
- [x] HTML table format follows existing convention
- [x] Tag badges follow existing color scheme