### PR TITLE
Add SQLite Graph Memory to Systems and Open Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -10851,6 +10851,7 @@ Systems below are ordered by **publication date**:
 | Engrava | 2026-06-02 | ![GitHub Repo stars](https://img.shields.io/github/stars/sovantica/engrava?style=social) | https://github.com/sovantica/engrava<br>https://engrava.ai |
 | Mimir | 2026-06-06 | ![GitHub Repo stars](https://img.shields.io/github/stars/tcconnally/mimir?style=social) | https://github.com/tcconnally/mimir<br>https://perseus.observer/mimir |
 | AccInt | 2026-06-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/maxbaluev/accreted-intelligence?style=social) | https://github.com/maxbaluev/accreted-intelligence<br>https://accint.xyz/ |
+| SQLite Graph Memory | 2026-07-03 | ![GitHub Repo stars](https://img.shields.io/github/stars/Palo-Alto-AI-Research-Lab/sqlite-graph-memory?style=social) | https://github.com/Palo-Alto-AI-Research-Lab/sqlite-graph-memory<br>No official website |
 | Tree Ring Memory | 2026-07-07 | ![GitHub Repo stars](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory?style=social) | https://github.com/TerminallyLazy/Tree-Ring-Memory<br>https://terminallylazy.github.io/Tree-Ring-Memory/ |
 | Data Olympus | 2026-07-08 | ![GitHub Repo stars](https://img.shields.io/github/stars/knaisoma/data-olympus?style=social) | https://github.com/knaisoma/data-olympus<br>No official website |
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -10811,6 +10811,7 @@ Framework for Experience-Driven Agent Evolution</strong></td>
 | Engrava | 2026-06-02 | ![GitHub Repo stars](https://img.shields.io/github/stars/sovantica/engrava?style=social) | https://github.com/sovantica/engrava<br>https://engrava.ai |
 | Mimir | 2026-06-06 | ![GitHub Repo stars](https://img.shields.io/github/stars/tcconnally/mimir?style=social) | https://github.com/tcconnally/mimir<br>https://perseus.observer/mimir |
 | AccInt | 2026-06-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/maxbaluev/accreted-intelligence?style=social) | https://github.com/maxbaluev/accreted-intelligence<br>https://accint.xyz/ |
+| SQLite Graph Memory | 2026-07-03 | ![GitHub Repo stars](https://img.shields.io/github/stars/Palo-Alto-AI-Research-Lab/sqlite-graph-memory?style=social) | https://github.com/Palo-Alto-AI-Research-Lab/sqlite-graph-memory<br>No official website |
 | Tree Ring Memory | 2026-07-07 | ![GitHub Repo stars](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory?style=social) | https://github.com/TerminallyLazy/Tree-Ring-Memory<br>https://terminallylazy.github.io/Tree-Ring-Memory/ |
 | Data Olympus | 2026-07-08 | ![GitHub Repo stars](https://img.shields.io/github/stars/knaisoma/data-olympus?style=social) | https://github.com/knaisoma/data-olympus<br>No official website |
 


### PR DESCRIPTION
One open-source memory system added to **💻 Systems and Open Sources**, in publication-date order (2026-07-03, the repository creation date), and mirrored in both `README.md` and `README_cn.md` as the contributing guide requires.

**System:** [SQLite Graph Memory](https://github.com/Palo-Alto-AI-Research-Lab/sqlite-graph-memory) — Graph RAG for agent long-term memory on plain SQLite. Retrieval combines vector search, a hand-curated wikilink graph over the note corpus, and a cross-encoder rerank step; a separate per-turn ledger records memory state with no LLM call, so recall costs zero tokens until something is actually retrieved.

**Why it may interest this list:** most entries in the table are hosted services or heavier stacks. This one is deliberately the opposite end — a single-file SQLite store with no server and no vendor, which makes it easy to reproduce and to run fully offline. The wikilink graph is curated by a human rather than extracted by an LLM, which is a different point on the precision/recall trade-off than most graph-memory systems here.

**Details:** MIT licensed, working pilot, no paid backend. No website, so the website cell says "No official website" in the existing style.

Checked the table for a duplicate entry — nothing matching this project. Happy to adjust the date or the row if you order by first public release rather than repository creation.