### PR TITLE
docs: add Mengram to the systems list

### DIFF
--- a/README.md
+++ b/README.md
@@ -10823,6 +10823,7 @@ Systems below are ordered by **publication date**:
 | Autohand Code CLI | 2025-12-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/autohandai/code-cli?style=social) | https://github.com/autohandai/code-cli<br>https://www.autohand.ai/code/ |
 | Hindsight   | 2025-12-22 | ![GitHub Repo stars](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social) | https://github.com/vectorize-io/hindsight<br>https://hindsight.vectorize.io/ |
 | MAGMA       | 2026-01-06 | ![GitHub Repo stars](https://img.shields.io/github/stars/FredJiang0324/MAMGA?style=social) | https://github.com/FredJiang0324/MAMGA<br>No official website |
+| Mengram | 2026-02-11 | ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social) | https://github.com/alibaizhanov/mengram<br>https://mengram.io/ |
 | widemem-ai | 2026-02-23 | ![GitHub Repo stars](https://img.shields.io/github/stars/remete618/widemem-ai?style=social) | https://github.com/remete618/widemem-ai<br>https://widemem.ai |
 | Riverse | 2026-02-25 | ![GitHub Repo stars](https://img.shields.io/github/stars/wangjiake/JKRiver?style=social) | https://github.com/wangjiake/JKRiver<br>https://wangjiake.github.io/riverse-docs/ |
 | SuperLocalMemory | 2026-03-01 | ![GitHub Repo stars](https://img.shields.io/github/stars/qualixar/superlocalmemory?style=social) | https://github.com/qualixar/superlocalmemory<br>https://superlocalmemory.com/ |


### PR DESCRIPTION
Adds [Mengram](https://mengram.io) to the Systems and Open Sources table.

Mengram is an open-core (Apache-2.0) memory layer for AI agents with three memory types — semantic (facts), episodic (events), and **procedural** (workflows that learn from failures, stored as versioned rows with success/fail counts and preconditions derived from violated assumptions). It works with Claude Code, Cursor, and any MCP client, is multilingual, and has a free tier.

First released 2026-02-11 (placed in the date-ordered table between MAGMA and widemem-ai).

- GitHub: https://github.com/alibaizhanov/mengram
- Website: https://mengram.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)