### PR TITLE
Add Superself to Systems and Open Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -10853,6 +10853,7 @@ Systems below are ordered by **publication date**:
 | AccInt | 2026-06-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/maxbaluev/accreted-intelligence?style=social) | https://github.com/maxbaluev/accreted-intelligence<br>https://accint.xyz/ |
 | Tree Ring Memory | 2026-07-07 | ![GitHub Repo stars](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory?style=social) | https://github.com/TerminallyLazy/Tree-Ring-Memory<br>https://terminallylazy.github.io/Tree-Ring-Memory/ |
 | Data Olympus | 2026-07-08 | ![GitHub Repo stars](https://img.shields.io/github/stars/knaisoma/data-olympus?style=social) | https://github.com/knaisoma/data-olympus<br>No official website |
+| Superself | 2026-07-23 | ![GitHub Repo stars](https://img.shields.io/github/stars/fxylabs/superself?style=social) | https://github.com/fxylabs/superself<br>https://superselfs.com/ |
 
 ### 🎥 Multi-media resource
 


### PR DESCRIPTION
Adds Superself to Systems and Open Sources.

Superself is an event-sourced state layer for agent sessions: goals, decisions, work units and reports live in an append-only log outside the code repository, and the current state is projected into the session's context at start rather than retrieved on demand. It sits at the boundary of this list — a state projection rather than a recall system — and is included as the derivation-side counterpart to the retrieval systems already listed.

Apache-2.0, first commit 2026-07-23.

Disclosure: I am the author of the linked project, and this PR was drafted with Claude Code.