### PR TITLE
Add ViBo — encrypted memory for AI agents (97.5% fewer tokens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10853,6 +10853,7 @@ Systems below are ordered by **publication date**:
 | AccInt | 2026-06-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/maxbaluev/accreted-intelligence?style=social) | https://github.com/maxbaluev/accreted-intelligence<br>https://accint.xyz/ |
 | Tree Ring Memory | 2026-07-07 | ![GitHub Repo stars](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory?style=social) | https://github.com/TerminallyLazy/Tree-Ring-Memory<br>https://terminallylazy.github.io/Tree-Ring-Memory/ |
 | Data Olympus | 2026-07-08 | ![GitHub Repo stars](https://img.shields.io/github/stars/knaisoma/data-olympus?style=social) | https://github.com/knaisoma/data-olympus<br>No official website |
+| ViBo | 2026-08-13 | ![GitHub Repo stars](https://img.shields.io/github/stars/vnbochkarev-netizen/ViBo-memory) | [GitHub](https://github.com/vnbochkarev-netizen/ViBo-memory) · [Site](https://wwwvibo.com) — encrypted L1/L2/L3 memory, web search savings 99.6%, thread memory |
 
 ### 🎥 Multi-media resource
 


### PR DESCRIPTION
## Add ViBo to the systems table

**ViBo** — memory for AI agents:
- 🧠 Encrypted L1/L2/L3 memory (secrets never reach the LLM)
- 🌐 Web search savings: 47,443 → 186 tokens (99.6% measured)
- 💬 Thread memory: conversations -72%, details restored on demand
- Measured: 118 facts → 263 tokens instead of 13,775 (97.5% fewer)
- Works with any agent: OpenClaw, LangChain, n8n, MCP
- Model: $5/month, 2-day free trial

Site: https://wwwvibo.com · Docs: https://github.com/vnbochkarev-netizen/ViBo-memory