### PR TITLE
Correct comparison count in ZenBrain entry (9/9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2887,7 +2887,7 @@ Papers below are ordered by **publication date**:
       <tr>
         <td colspan="3">
           • Introduces ZenBrain, a seven-layer long-term memory architecture for autonomous agents that combines neuroscience-inspired mechanisms — Hebbian learning, FSRS spaced repetition, sleep-cycle consolidation, and Bayesian confidence propagation — released as an open-source, zero-dependency TypeScript library (Apache-2.0).<br>
-          • On LongMemEval-500 it attains 91.3% of oracle accuracy at 1/106 of the token budget, with 12/12 Bonferroni-corrected head-to-head wins over Letta, Mem0, and A-Mem.<br>
+          • On LongMemEval-500 it attains 91.3% of oracle accuracy at 1/106 of the token budget, with 9/9 Bonferroni-corrected head-to-head wins over Letta, Mem0, and A-Mem.<br>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Correcting our own entry to match the paper.

On LongMemEval-500 the paper reports **nine** Bonferroni-corrected head-to-head answer-quality comparisons, three competitors times three LLM judges, and ZenBrain wins **all nine** (App. F.2, p_min = 6.2e-31, d in [0.18, 0.52]).

The earlier figure of twelve counted the four-by-three result grid, which includes ZenBrain's own column. Both the current arXiv version and the Zenodo record carry the corrected wording.

Everything else in the entry stays as it is. Thanks for maintaining this list.
