### PR TITLE
Add kgai to Systems and Open Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -10907,6 +10907,7 @@ Systems below are ordered by **publication date**:
 | Compartment | 2026-07-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social) | https://github.com/MaxFreedomPollard/Compartment<br>No official website |
 | OpenViking | 2026-08-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/volcengine/OpenViking?style=social) | https://github.com/volcengine/OpenViking<br>https://openviking.ai/ |
 | Verified Memory Vault | 2026-08-24 | ![GitHub Repo stars](https://img.shields.io/github/stars/secondbrainstarter/verified-memory-vault?style=social) | https://github.com/secondbrainstarter/verified-memory-vault<br>https://secondbrainstarter.github.io/verified-memory-vault/ |
+| kgai | 2026-08-03 | ![GitHub Repo stars](https://img.shields.io/github/stars/kgaidev/kgai?style=social) | https://github.com/kgaidev/kgai<br>https://kgai.dev/?ref=awesome-ai-memory |
 
 ### 🎥 Multi-media resource
 


### PR DESCRIPTION
Disclosure up front: I work on kgai, so this is a self-submission. Feel free to reject it or reshape the entry.

kgai is shared decision memory for dev teams. It records the engineering decisions behind a codebase as an immutable, append-only log, keeps rejected approaches with the reason they were dropped, and syncs the log across a team over an S3 bucket you own. Local-first, MIT, install is two commands.

The header says systems are ordered by publication date, and the last few rows have drifted out of that order, so I appended kgai at the end rather than guess at a reshuffle. The repo went public 2026-08-03. One line in README.md, nothing else touched. Happy to shorten the description, move the row into date position, or adjust the format to whatever you prefer.