### PR TITLE
Add chamnan to Systems and Open Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -10906,8 +10906,8 @@ Systems below are ordered by **publication date**:
 | Superself | 2026-07-23 | ![GitHub Repo stars](https://img.shields.io/github/stars/fxylabs/superself?style=social) | https://github.com/fxylabs/superself<br>https://superselfs.com/ |
 | Compartment | 2026-07-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social) | https://github.com/MaxFreedomPollard/Compartment<br>No official website |
 | OpenViking | 2026-08-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/volcengine/OpenViking?style=social) | https://github.com/volcengine/OpenViking<br>https://openviking.ai/ |
-| Verified Memory Vault | 2026-08-24 | ![GitHub Repo stars](https://img.shields.io/github/stars/secondbrainstarter/verified-memory-vault?style=social) | https://github.com/secondbrainstarter/verified-memory-vault<br>https://secondbrainstarter.github.io/verified-memory-vault/ |
 | chamnan | 2026-08-19 | ![GitHub Repo stars](https://img.shields.io/github/stars/ArcticFox2029/chamnan?style=social) | https://github.com/ArcticFox2029/chamnan |
+| Verified Memory Vault | 2026-08-24 | ![GitHub Repo stars](https://img.shields.io/github/stars/secondbrainstarter/verified-memory-vault?style=social) | https://github.com/secondbrainstarter/verified-memory-vault<br>https://secondbrainstarter.github.io/verified-memory-vault/ |
 
 ### 🎥 Multi-media resource
 

--- a/README.md
+++ b/README.md
@@ -10907,6 +10907,7 @@ Systems below are ordered by **publication date**:
 | Compartment | 2026-07-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social) | https://github.com/MaxFreedomPollard/Compartment<br>No official website |
 | OpenViking | 2026-08-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/volcengine/OpenViking?style=social) | https://github.com/volcengine/OpenViking<br>https://openviking.ai/ |
 | Verified Memory Vault | 2026-08-24 | ![GitHub Repo stars](https://img.shields.io/github/stars/secondbrainstarter/verified-memory-vault?style=social) | https://github.com/secondbrainstarter/verified-memory-vault<br>https://secondbrainstarter.github.io/verified-memory-vault/ |
+| chamnan | 2026-08-19 | ![GitHub Repo stars](https://img.shields.io/github/stars/ArcticFox2029/chamnan?style=social) | https://github.com/ArcticFox2029/chamnan |
 
 ### 🎥 Multi-media resource
 


### PR DESCRIPTION
Adds `chamnan` to **Resources → Systems and Open Sources**, one row, appended at the end since the table is ordered by publication date (first release 2026-08-19).

In scope per the Project Scope section: *"Open-source frameworks and tools for memory-enhanced LLMs"* and *"memory systems in intelligent agents"*.

**What it is.** External, explicit memory for a coding agent, scoped to a single repository and stored as **markdown committed beside the code** — an architecture index, an impact map, session records, and the decisions behind them. A session reads that instead of rediscovering the repository, and the artifacts remain readable and version-controlled if the tool is removed.

It sits at the opposite end from the embedding- and graph-backed systems already listed: no vector store, no graph, no database — plain files and grep. That is a deliberate trade, and the README publishes how each figure was measured so the trade can be judged rather than taken on trust. On a deliberately hostile polyglot corpus, 11.5M tokens of source become a 52k-token index, of which roughly 3k reach any one session.

No network calls, no telemetry, Python standard library only, MIT.
