### PR TITLE
Add Engraphy to Systems and Open Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -10906,6 +10906,7 @@ Systems below are ordered by **publication date**:
 | Superself | 2026-07-23 | ![GitHub Repo stars](https://img.shields.io/github/stars/fxylabs/superself?style=social) | https://github.com/fxylabs/superself<br>https://superselfs.com/ |
 | Compartment | 2026-07-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social) | https://github.com/MaxFreedomPollard/Compartment<br>No official website |
 | OpenViking | 2026-08-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/volcengine/OpenViking?style=social) | https://github.com/volcengine/OpenViking<br>https://openviking.ai/ |
+| Engraphy | 2026-08-22 | ![GitHub Repo stars](https://img.shields.io/github/stars/devon-clarkk/engraphy?style=social) | https://github.com/devon-clarkk/engraphy<br>https://engraphy.tech |
 | Verified Memory Vault | 2026-08-24 | ![GitHub Repo stars](https://img.shields.io/github/stars/secondbrainstarter/verified-memory-vault?style=social) | https://github.com/secondbrainstarter/verified-memory-vault<br>https://secondbrainstarter.github.io/verified-memory-vault/ |
 
 ### 🎥 Multi-media resource


### PR DESCRIPTION
Adds [Engraphy](https://github.com/devon-clarkk/engraphy) to the Systems and Open Sources table, placed by publication date (2026-08-22, the first tagged release) between OpenViking and Verified Memory Vault.

Engraphy is a self-hosted memory engine for AI agents, spoken over the Model Context Protocol. Memories are typed nodes joined by typed edges on Postgres + pgvector, with the node types, their attribute schemas, and the legal edges between them declared per space and enforced in the database.

Two properties that distinguish it from most of the systems already in this table:

1. Writes reconcile before they land. Every write is embedded and banded against existing memory. A near-verbatim restatement merges, a genuinely new but related fact is kept as its own searchable node and joined by an edge, and a borderline case parks as a pending verdict for the caller to resolve. Nothing is deleted, so history stays walkable.
2. Isolation is enforced by Postgres Row-Level Security under a `NOBYPASSRLS` role, rather than by application-level checks.

Retrieval fuses a vector leg (cosine over embeddings) and a lexical leg (Postgres full-text) with Reciprocal Rank Fusion, and `traverse` walks the edges. On LoCoMo it scores 67.1%, with the adversarial category excluded as the denominator. The figure and the method behind it are published at https://engraphy.tech and broken down per category at https://engraphy.tech/compare/engraphy-vs-mem0

Python 3.12+, Postgres 16 + pgvector. Licensed under BSL 1.1, converting to Apache-2.0 at the Change Date. Website: https://engraphy.tech