### PR TITLE
Add causal-memory (Systems and Open Sources)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10907,6 +10907,7 @@ Systems below are ordered by **publication date**:
 | Compartment | 2026-07-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social) | https://github.com/MaxFreedomPollard/Compartment<br>No official website |
 | OpenViking | 2026-08-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/volcengine/OpenViking?style=social) | https://github.com/volcengine/OpenViking<br>https://openviking.ai/ |
 | Verified Memory Vault | 2026-08-24 | ![GitHub Repo stars](https://img.shields.io/github/stars/secondbrainstarter/verified-memory-vault?style=social) | https://github.com/secondbrainstarter/verified-memory-vault<br>https://secondbrainstarter.github.io/verified-memory-vault/ |
+| causal-memory | 2026-07-26 | ![GitHub Repo stars](https://img.shields.io/github/stars/JingxuanC/causal-memory?style=social) | https://github.com/JingxuanC/causal-memory<br>No official website |
 
 ### 🎥 Multi-media resource
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -10866,6 +10866,7 @@ Framework for Experience-Driven Agent Evolution</strong></td>
 | Superself | 2026-07-23 | ![GitHub Repo stars](https://img.shields.io/github/stars/fxylabs/superself?style=social) | https://github.com/fxylabs/superself<br>https://superselfs.com/ |
 | Compartment | 2026-07-20 | ![GitHub Repo stars](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social) | https://github.com/MaxFreedomPollard/Compartment<br>No official website |
 | OpenViking | 2026-08-15 | ![GitHub Repo stars](https://img.shields.io/github/stars/volcengine/OpenViking?style=social) | https://github.com/volcengine/OpenViking<br>https://openviking.ai/ |
+| causal-memory | 2026-07-26 | ![GitHub Repo stars](https://img.shields.io/github/stars/JingxuanC/causal-memory?style=social) | https://github.com/JingxuanC/causal-memory<br>No official website |
 
 ### 🎥 多媒体资源
 


### PR DESCRIPTION
## Summary
- Add [causal-memory](https://github.com/JingxuanC/causal-memory) to the Systems and Open Sources table (both README.md and README_cn.md)

## About the project
causal-memory is an agent memory system with a causal core: it stores flat facts, temporal state, and decision→outcome causal edges (typed caused / enabled / prevented) on a single local SQLite database. It ships as an MCP server (stdio + Streamable HTTP), a CLI, and Python bindings, and memory survives context compaction structurally since the store lives outside the context window. Written in Rust, Apache-2.0.

## Test plan
- [x] Entry added to README.md (Systems and Open Sources table)
- [x] Entry added to README_cn.md (same table)
- [x] Format matches existing rows (name, publication date, stars badge, GitHub link)