### PR TITLE
Correct comparison count in ZenBrain entry (README_cn.md)

### DIFF
--- a/README_cn.md
+++ b/README_cn.md
@@ -2905,7 +2905,7 @@ To systematically organize the diverse research and practical resources in the f
       <tr>
         <td colspan="3">
           • 推出 ZenBrain——一种面向自主智能体的七层长期记忆架构，融合了受神经科学启发的多种机制——包括赫布学习（Hebbian learning）、FSRS 间隔重复、睡眠周期巩固和贝叶斯置信传播——并以开源、零依赖的 TypeScript 库形式发布。<br>
-          • 在 LongMemEval-500 评测中，它仅用 1/106 的 token 预算即达到 91.3% 的 oracle 准确率，并在与 Letta、Mem0 和 A-Mem 的逐一对比中取得 12/12 全胜。<br>
+          • 在 LongMemEval-500 评测中，它仅用 1/106 的 token 预算即达到 91.3% 的 oracle 准确率，并在与 Letta、Mem0 和 A-Mem 的逐一对比中取得经 Bonferroni 校正的 9/9 全胜。<br>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Correcting our own entry to match the paper.

On LongMemEval-500 the paper reports **nine** Bonferroni-corrected head-to-head answer-quality comparisons, three competitors times three LLM judges, and ZenBrain wins **all nine** (App. F.2, p_min = 6.2e-31, d in [0.18, 0.52]).

The earlier figure of twelve counted the four-by-three result grid, which includes ZenBrain's own column.

The English README was corrected in #145 and already reads "9/9 Bonferroni-corrected head-to-head wins". This PR brings the Chinese translation of the same line (README_cn.md, line 2908) in line with it:

```diff
- 并在与 Letta、Mem0 和 A-Mem 的逐一对比中取得 12/12 全胜。
+ 并在与 Letta、Mem0 和 A-Mem 的逐一对比中取得经 Bonferroni 校正的 9/9 全胜。
```

One line changed, nothing else. Thanks for maintaining this list.